### PR TITLE
fix issue in mysql

### DIFF
--- a/src/list_mgr/listmgr_init.c
+++ b/src/list_mgr/listmgr_init.c
@@ -2150,7 +2150,7 @@ static int create_table_softrm(db_conn_t *pconn, bool *affects_trig)
 #define VERSION_VAR_TRIG    "VersionTriggerSet"
 
 #define FUNCTIONSET_VERSION    "1.6"
-#define TRIGGERSET_VERSION     "1.5"
+#define TRIGGERSET_VERSION     "1.6"
 
 static int check_functions_version(db_conn_t *conn)
 {
@@ -2475,12 +2475,12 @@ static int create_trig_acct_update(db_conn_t *pconn, bool *affects_trig)
         if (is_acct_field(i)) {
             if (!is_first_field)
                 g_string_append_printf(request,
-                                       ",%s=%s+CAST(NEW.%s as SIGNED)-CAST(OLD.%s as SIGNED)",
+                                       ",%s=CAST(%s as SIGNED)+CAST(NEW.%s as SIGNED)-CAST(OLD.%s as SIGNED)",
                                        field_name(i), field_name(i),
                                        field_name(i), field_name(i));
             else {
                 g_string_append_printf(request,
-                                       "%s=%s+CAST(NEW.%s as SIGNED)-CAST(OLD.%s as SIGNED)",
+                                       ",%s=CAST(%s as SIGNED)+CAST(NEW.%s as SIGNED)-CAST(OLD.%s as SIGNED)",
                                        field_name(i), field_name(i),
                                        field_name(i), field_name(i));
                 is_first_field = false;


### PR DESCRIPTION
MySQL operations with any unsigned int (either on left-hand side or the
right-hand side) are unsigned, so size needs to be explicitly CAST()'ed
to SIGNED to avoid conversion errors.

This should fix errors like these:

Out of range value for column 'size' at row 3

You will need to drop and repopulate the accounting table to totally get
rid of the errors because some ACCT fields may contain invalid values.
You can do this using "rbh-config reset_acct".  On next startup,
robinhood will populate the ACCT table with the right information (this
may take a few hours depending on the filesystem size).