### PR TITLE
fix build issue which caused by multi-client installed

### DIFF
--- a/autotools/m4/lustre.m4
+++ b/autotools/m4/lustre.m4
@@ -13,8 +13,11 @@ AC_DEFUN([AX_LUSTRE_VERSION],
             LPACKAGE=lustre-client
             # Assume we want the same version as this package,
             # whatever 'lustre' or 'lustre-client'
+            #
+            # Added pipe to 'head -1' to properly handle cases of multiple packages; lustre-client and lustre-client-dkms
+            #
             AC_MSG_CHECKING(Lustre version)
-            LVERSION=`rpm -q --whatprovides lustre-client --qf "%{Version}\n" 2>/dev/null | grep -v "no package" | cut -d "." -f 1-2`
+            LVERSION=`rpm -q --whatprovides lustre-client --qf "%{Version}\n" 2>/dev/null | grep -v "no package" | cut -d "." -f 1-2 | head -1`
             AC_MSG_RESULT($LVERSION)
         else
             AC_MSG_RESULT(no)


### PR DESCRIPTION
root@host robinhood-patchs]# ./configure
......
checking Lustre version... 2.15
2.15
......

checking sys/xattr.h usability... no
checking sys/xattr.h presence... yes
configure: WARNING: sys/xattr.h: present but cannot be compiled
configure: WARNING: sys/xattr.h:     check for missing prerequisite headers?
configure: WARNING: sys/xattr.h: see the Autoconf documentation
configure: WARNING: sys/xattr.h:     section "Present But Cannot Be Compiled"
configure: WARNING: sys/xattr.h: proceeding with the compiler's result
configure: WARNING:     ## ------------------------------------------------------ ##
configure: WARNING:     ## Report this to robinhood-support@lists.sourceforge.net ##
configure: WARNING:     ## ------------------------------------------------------ ##
checking for sys/xattr.h... no
configure: error: glibc-devel is not installed.

[root@host robinhood-patchs]# rpm -qa|grep glibc-devel
glibc-devel-2.28-251.el8_10.2.x86_64

[root@host robinhood-patchs]#

[root@host robinhood-patchs]# rpm -qa|grep lustre-client
......
lustre-client-dkms-2.15.5-1.el8.noarch
lustre-client-2.15.5-1.el8.x86_64
[root@host ~]#
