### PR TITLE
fix issue of mysql type build error

### DIFF
--- a/src/list_mgr/mysql_wrapper.c
+++ b/src/list_mgr/mysql_wrapper.c
@@ -115,7 +115,7 @@ bool db_is_retryable(int db_err)
 /* create client connection */
 int db_connect(db_conn_t *conn)
 {
-    my_bool reconnect = 1;
+    int reconnect = 1;
     unsigned int retry = 0;
 
     /* Connect to database */


### PR DESCRIPTION
Making all in list_mgr
make[2]: Entering directory '/root/robinhood-patchs/src/list_mgr'
  CC       mysql_wrapper.lo
mysql_wrapper.c: In function ‘db_connect’:
mysql_wrapper.c:118:5: error: unknown type name ‘my_bool’; did you mean ‘bool’?
     my_bool reconnect = 1;
     ^~~~~~~
     bool
make[2]: *** [Makefile:467: mysql_wrapper.lo] Error 1
make[2]: Leaving directory '/root/robinhood-patchs/src/list_mgr'