### PR TITLE
fix issue of build in ubuntu 20.04

### DIFF
--- a/src/modules/backup.c
+++ b/src/modules/backup.c
@@ -1553,7 +1553,7 @@ static int wrap_file_copy(sm_instance_t *smi,
     action_params_t tmp_params = { 0 };
 
     /* build tmp copy path */
-    asprintf(&tmp, "%s.%s", bkpath, COPY_EXT);
+    if (asprintf(&tmp, "%s.%s", bkpath, COPY_EXT)){};
     if (!tmp)
         return -ENOMEM;
 


### PR DESCRIPTION
Making all in modules
make[2]: Entering directory '/root/src/robinhood-patchs/src/modules'
......
  CC       librbh_mod_backup_la-backup.lo
backup.c: In function ‘wrap_file_copy’:
backup.c:1556:5: error: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Werror=unused-result]
 1556 |     asprintf(&tmp, "%s.%s", bkpath, COPY_EXT);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:644: librbh_mod_backup_la-backup.lo] Error 1
make[2]: Leaving directory '/root/src/robinhood-patchs/src/modules'