### PR TITLE
fix build issue with gcc-toolset-13

### DIFF
--- a/src/list_mgr/listmgr_common.c
+++ b/src/list_mgr/listmgr_common.c
@@ -771,7 +771,14 @@ int attrset2updatelist(lmgr_t *p_mgr, GString *str, const attr_set_t *p_set,
             if (leading_comma || (nbfields > 0))
                 g_string_append(str, ",");
 
+/* fix issue of error: ‘%s’ directive argument is null [-Werror=format-overflow=] */
+/* which found in almaLinux with gcc-toolset-13 */
+#if __GNUC__ >= 13
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-overflow"
             g_string_append_printf(str, "%s=", field_name(i));
+#pragma GCC diagnostic pop
+#endif
 
             if (generic_value)
                 g_string_append_printf(str, "VALUES(%s)", field_name(i));
@@ -1208,12 +1215,19 @@ static void attr2filter_field(GString *str, table_enum table,
 
             print_func_call(str, attr, prefix);
         } else {    /* std field */
+/* fix issue of error: ‘%s’ directive argument is null [-Werror=format-overflow=] */
+/* which found in almaLinux with gcc-toolset-13 */
+#if __GNUC__ >= 13
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-overflow"
 
             if (prefix_table)
                 g_string_append_printf(str, "%s.",
                                        table2name(table ==
                                                   T_NONE ? field2table(attr) :
                                                   table));
+#pragma GCC diagnostic pop
+#endif
 
             g_string_append(str, field_name(attr));
         }

--- a/src/list_mgr/listmgr_remove.c
+++ b/src/list_mgr/listmgr_remove.c
@@ -61,8 +61,15 @@ static inline void append_table_join(GString *fields, GString *tables, GString *
         g_string_printf(tables, "%s %s", tname, talias);
     }
     else
+/* fix issue of error: ‘%s’ directive argument is null [-Werror=format-overflow=] */
+/* which found in almaLinux with gcc-toolset-13 */
+#if __GNUC__ >= 13
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-overflow"
         g_string_append_printf(tables, " LEFT JOIN %s %s ON %s.id = %s.id",
                                tname, talias, *first_table, talias);
+#pragma GCC diagnostic pop
+#endif
 
     if (GSTRING_EMPTY(where))
         g_string_printf(where, "%s.id="DPK, talias, pk);


### PR DESCRIPTION
fix build issue as following example:

listmgr_common.c: In function ‘attr2filter_field’:
listmgr_common.c:1213:46: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
 1213 |                 g_string_append_printf(str, "%s.",
      |                                              ^~
listmgr_common.c:1213:46: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
listmgr_common.c: In function ‘attrset2updatelist’:
listmgr_common.c:774:42: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  774 |             g_string_append_printf(str, "%s=", field_name(i));
      |                                          ^~
listmgr_common.c:774:42: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
