### PR TITLE
fix build issue in gcc-14

### DIFF
--- a/src/list_mgr/listmgr_iterators.c
+++ b/src/list_mgr/listmgr_iterators.c
@@ -150,6 +150,14 @@ static inline void check_sort(const lmgr_sort_type_t *p_sort_type,
         || ((p_sort_type->attr_index & ATTR_INDEX_FLG_UNSPEC) != 0))
         return;
 
+    if (p_sort_type->attr_index >= ATTR_COUNT)
+    {
+        DisplayLog(LVL_CRIT, LISTMGR_TAG,
+                    "Invalid attribute index value (%d)",
+                    p_sort_type->attr_index);
+        return;
+    }
+
     /* check sort order */
     if (is_main_field(p_sort_type->attr_index))
         *t_sort = T_MAIN;


### PR DESCRIPTION
fix build issue in ubuntu 24.04 with gcc-14 installed

In function 'check_sort',
    inlined from 'ListMgr_Iterator' at listmgr_iterators.c:225:5:
listmgr_iterators.c:158:25: error: array subscript 27 is above array bounds of 'const field_info_t[27]' [-Werror=array-bounds=]
  158 |     else if (field_infos[p_sort_type->attr_index].db_type == DB_STRIPE_INFO)
      |              ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~