### PR TITLE
fix issue of hang for everconnect to non-started mysql

### DIFF
--- a/src/list_mgr/mysql_wrapper.c
+++ b/src/list_mgr/mysql_wrapper.c
@@ -132,6 +132,11 @@ int db_connect(db_conn_t *conn)
     conn->reconnect = 1;
 #endif
 
+    // set connection timeout to prevent hang in mysql_real_connect function call
+    // when remote MySQL server not running
+    unsigned int conn_timeout = 30;
+    mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, (const void *)&conn_timeout);
+
     while (1) {
         /* connect to server */
         if (!mysql_real_connect


### PR DESCRIPTION
#7  0x00007f1784074926 in ?? () from /lib/x86_64-linux-gnu/libmariadb.so.3
#8  0x00007f1784076061 in mysql_real_query () from /lib/x86_64-linux-gnu/libmariadb.so.3
#9  0x000000000046fc88 in db_connect ()
#10 0x00000000004581a2 in ListMgr_InitAccess ()